### PR TITLE
add 15 seconds initialisation delay for menu items

### DIFF
--- a/addon/content/scripts/index.js
+++ b/addon/content/scripts/index.js
@@ -62,40 +62,86 @@
       
       ReplicationChecker.log("Setting up UI...");
       
-      // Add to Tools menu
+      // Add to Tools menu (disabled initially)
       const toolsPopup = win.document.getElementById('menu_ToolsPopup');
       if (toolsPopup) {
         const menuitem = win.document.createXULElement('menuitem');
         menuitem.id = 'replication-checker-tools-menu';
-        menuitem.setAttribute('label', 'Check Library for Replications');
+        menuitem.setAttribute('label', 'Check Library for Replications (Initializing...)');
+        menuitem.setAttribute('disabled', 'true');
         menuitem.addEventListener('command', () => {
           ReplicationCheckerPlugin.checkEntireLibrary();
         });
         toolsPopup.appendChild(menuitem);
         ReplicationChecker.menuItems = ReplicationChecker.menuItems || [];
         ReplicationChecker.menuItems.push(menuitem);
-        ReplicationChecker.log("✓ Tools menu item added");
+        ReplicationChecker.log("✓ Tools menu item added (disabled)");
       }
       
-      // Add to item context menu
+      // Add to item context menu (disabled initially)
       const itemMenu = win.document.getElementById('zotero-itemmenu');
       if (itemMenu) {
         const menuitem = win.document.createXULElement('menuitem');
         menuitem.id = 'replication-checker-context-menu';
-        menuitem.setAttribute('label', 'Check for Replications');
+        menuitem.setAttribute('label', 'Check for Replications (Initializing...)');
+        menuitem.setAttribute('disabled', 'true');
         menuitem.addEventListener('command', () => {
           ReplicationCheckerPlugin.checkSelectedItems();
         });
         itemMenu.appendChild(menuitem);
         ReplicationChecker.menuItems = ReplicationChecker.menuItems || [];
         ReplicationChecker.menuItems.push(menuitem);
-        ReplicationChecker.log("✓ Context menu item added");
+        ReplicationChecker.log("Context menu item added (disabled)");
       }
       
-      ReplicationChecker.log("✓ UI setup complete");
+      ReplicationChecker.log("UI setup complete (menus disabled)");
+      
+      // Enable menus after 15 seconds (15000 milliseconds)
+      ReplicationChecker.log("Scheduling menu enablement in 15 seconds...");
+      setTimeout(() => {
+        enableMenus();
+      }, 15000);
       
     } catch (error) {
       ReplicationChecker.log("ERROR setting up UI: " + error);
+      Zotero.logError(error);
+    }
+  }
+  
+  /**
+   * Enable menu items after initialization period
+   */
+  function enableMenus() {
+    try {
+      ReplicationChecker.log("Enabling menu items...");
+      
+      const win = Zotero.getMainWindow();
+      if (!win || !win.document) {
+        ReplicationChecker.log("Main window not available, retrying...");
+        setTimeout(enableMenus, 500);
+        return;
+      }
+      
+      // Enable Tools menu item
+      const toolsMenuItem = win.document.getElementById('replication-checker-tools-menu');
+      if (toolsMenuItem) {
+        toolsMenuItem.removeAttribute('disabled');
+        toolsMenuItem.setAttribute('label', 'Check Library for Replications');
+        ReplicationChecker.log("Tools menu item enabled");
+      }
+      
+      // Enable context menu item
+      const contextMenuItem = win.document.getElementById('replication-checker-context-menu');
+      if (contextMenuItem) {
+        contextMenuItem.removeAttribute('disabled');
+        contextMenuItem.setAttribute('label', 'Check for Replications');
+        ReplicationChecker.log("Context menu item enabled");
+      }
+      
+      ReplicationChecker.log("All menu items enabled and ready to use");
+      
+    } catch (error) {
+      ReplicationChecker.log("ERROR enabling menus: " + error);
       Zotero.logError(error);
     }
   }
@@ -117,7 +163,7 @@
         ReplicationChecker.menuItems = [];
       }
       
-      ReplicationChecker.log("✓ Cleanup complete");
+      ReplicationChecker.log("Cleanup complete");
     } catch (error) {
       ReplicationChecker.log("ERROR during cleanup: " + error);
     }


### PR DESCRIPTION
Disables "Check for Replications" menu items during plugin initialization to prevent errors. Menu items are grayed out with "(Initializing...)" label for 15 seconds, then automatically enabled once ready.