### PR TITLE
Search & Add for Replication studies when adding a new item

### DIFF
--- a/addon/content/scripts/index.js
+++ b/addon/content/scripts/index.js
@@ -93,6 +93,22 @@
         ReplicationChecker.menuItems.push(menuitem);
         ReplicationChecker.log("Context menu item added (disabled)");
       }
+
+      // Add to collection context menu (disabled initially)
+      const collectionMenu = win.document.getElementById('zotero-collectionmenu');
+      if (collectionMenu) {
+        const menuitem = win.document.createXULElement('menuitem');
+        menuitem.id = 'replication-checker-collection-menu';
+        menuitem.setAttribute('label', 'Check for Replications (Initializing...)');
+        menuitem.setAttribute('disabled', 'true');
+        menuitem.addEventListener('command', () => {
+          ReplicationCheckerPlugin.checkSelectedCollection();
+        });
+        collectionMenu.appendChild(menuitem);
+        ReplicationChecker.menuItems = ReplicationChecker.menuItems || [];
+        ReplicationChecker.menuItems.push(menuitem);
+        ReplicationChecker.log("Collection menu item added (disabled)");
+      }
       
       ReplicationChecker.log("UI setup complete (menus disabled)");
       
@@ -136,6 +152,14 @@
         contextMenuItem.removeAttribute('disabled');
         contextMenuItem.setAttribute('label', 'Check for Replications');
         ReplicationChecker.log("Context menu item enabled");
+      }
+
+      // Enable collection menu item
+      const collectionMenuItem = win.document.getElementById('replication-checker-collection-menu');
+      if (collectionMenuItem) {
+        collectionMenuItem.removeAttribute('disabled');
+        collectionMenuItem.setAttribute('label', 'Check for Replications');
+        ReplicationChecker.log("Collection menu item enabled");
       }
       
       ReplicationChecker.log("All menu items enabled and ready to use");

--- a/addon/content/scripts/replication-checker.js
+++ b/addon/content/scripts/replication-checker.js
@@ -14,7 +14,7 @@ var ReplicationCheckerPlugin = {
     this.rootURI = rootURI;
 
     try {
-      // Initialize data source with API (replaced CSV with API)
+      // Initialize data source with API
       Zotero.debug("Initializing data source with API");
 
       this.dataSource = new APIDataSource();
@@ -135,7 +135,7 @@ var ReplicationCheckerPlugin = {
       for (let i = 0; i < Math.min(replications.length, 3); i++) {
         const rep = replications[i];
         message += `${i + 1}. ${rep.title_r}\n`;
-        message += `   ${rep.author_r} (${rep.year_r})\n`;
+        message += `   ${this._parseAuthors(rep.author_r)} (${rep.year_r})\n`;
         message += `   Outcome: ${rep.outcome || 'Not specified'}\n\n`;
       }
 
@@ -202,7 +202,7 @@ var ReplicationCheckerPlugin = {
       for (let result of results) {
         if (result.replications.length > 0) {
           const matchingItems = libraryItems.filter(item =>
-            item.doi.toLowerCase() === result.doi.toLowerCase()
+              this.matcher._normalizeDoi(item.doi) === result.doi
           );
           for (let libraryItem of matchingItems) {
             if (!processedItems.has(libraryItem.itemID)) {
@@ -252,7 +252,7 @@ var ReplicationCheckerPlugin = {
       for (let result of results) {
         if (result.replications.length > 0) {
           const matchingItems = selectedItems.filter(item =>
-            item.doi.toLowerCase() === result.doi.toLowerCase()
+            this.matcher._normalizeDoi(item.doi) === result.doi
           );
           for (let libraryItem of matchingItems) {
             if (!processedItems.has(libraryItem.itemID)) {
@@ -271,9 +271,88 @@ var ReplicationCheckerPlugin = {
       }
 
       // Show simplified alert
-      this.showResultsAlert(results, selectedItems.length, selectedItems.length, true);
+      this.showResultsAlert(results, uniqueDois.length, selectedItems.length, true);
     } catch (error) {
       Zotero.logError("Error checking selected items: " + error);
+    }
+  },
+
+  /**
+   * Check selected collection for replications
+   */
+  async checkSelectedCollection() {
+    try {
+      const collection = Zotero.getActiveZoteroPane().getSelectedCollection();
+      if (!collection) {
+        const win = Zotero.getMainWindow();
+        if (win) {
+          win.alert("No Collection", "No collection selected");
+        }
+        return;
+      }
+
+      // Show progress
+      const progressWin = new Zotero.ProgressWindow();
+      progressWin.changeHeadline("Checking for Replications in Collection");
+      progressWin.show();
+      progressWin.addLines(["Scanning collection..."]);
+
+      // Get DOIs from collection
+      const selectedItems = await ZoteroIntegration.getDOIsFromCollection(collection.id);
+      Zotero.debug(`Retrieved ${selectedItems.length} items from collection ${collection.id}`);
+      if (!selectedItems || selectedItems.length === 0) {
+        progressWin.changeHeadline("Check Complete");
+        progressWin.addLines(["No items with DOIs found in collection"]);
+        progressWin.startCloseTimer(3000);
+        const win = Zotero.getMainWindow();
+        if (win) {
+          win.alert("No DOIs", "No DOIs found in collection");
+        }
+        return;
+      }
+
+      const uniqueDois = [...new Set(selectedItems.map(item => item.doi.toLowerCase()))].map(doi => selectedItems.find(item => item.doi.toLowerCase() === doi).doi); // Unique DOIs for querying
+
+      progressWin.addLines([`Found ${selectedItems.length} items with DOIs (${uniqueDois.length} unique)`]);
+      progressWin.addLines(["Checking against replication database..."]);
+
+      // Check for replications using the matcher and API
+      const results = await this.matcher.checkBatch(uniqueDois);
+
+      // Process results with unique item tracking
+      const processedItems = new Set();
+      let matchCount = 0;
+      for (let result of results) {
+        if (result.replications.length > 0) {
+          const matchingItems = selectedItems.filter(item =>
+            this.matcher._normalizeDoi(item.doi) === result.doi
+          );
+          for (let libraryItem of matchingItems) {
+            if (!processedItems.has(libraryItem.itemID)) {
+              const hasTag = await ZoteroIntegration.hasReplicationTag(libraryItem.itemID);
+              if (!hasTag || result.replications.length > 0) { // Ensure note is added if new replications are found
+                try {
+                  await this.notifyUser(libraryItem.itemID, result.replications);
+                  processedItems.add(libraryItem.itemID);
+                  matchCount++;
+                } catch (error) {
+                  Zotero.logError(`Error processing item ${libraryItem.itemID}: ${error.message}`);
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // Update progress
+      progressWin.changeHeadline("Check Complete");
+      progressWin.addLines([`Found replications for ${matchCount} items`]);
+      progressWin.startCloseTimer(3000);
+
+      // Show simplified alert
+      this.showResultsAlert(results, uniqueDois.length, selectedItems.length, false, true);
+    } catch (error) {
+      Zotero.logError("Error checking collection: " + error);
     }
   },
 
@@ -284,58 +363,193 @@ var ReplicationCheckerPlugin = {
    */
   async notifyUser(itemID, replications) {
     try {
-      // Add tag if not present
-      const hasTag = await ZoteroIntegration.hasReplicationTag(itemID);
-      if (!hasTag) {
+        const item = await Zotero.Items.getAsync(itemID);
+
+        // Deduplicate replications by doi_r
+        const seen = new Set();
+        const uniqueReplications = replications.filter(rep => {
+          const doi_r = (rep.doi_r || '').trim();
+          if (doi_r && !seen.has(doi_r)) {
+            seen.add(doi_r);
+            return true;
+          }
+          return false;
+        });
+
+        // Always add "Has Replication" tag if missing
         await ZoteroIntegration.addTag(itemID, "Has Replication");
-        // Add specific outcome tags (only if not already tagged)
+
+        // Add outcome tags based on current replications (duplicates ignored)
         const allowedOutcomes = {
-          successful: "Replication: Successful",
-          failure: "Replication: Failure",
-          mixed: "Replication: Mixed"
+            successful: "Replication: Successful",
+            failure: "Replication: Failure",
+            mixed: "Replication: Mixed"
         };
-
         const uniqueOutcomes = new Set(
-          replications
-            .map(r => r.outcome ? r.outcome.toLowerCase() : null)
-            .filter(o => o && Object.keys(allowedOutcomes).includes(o))
+            uniqueReplications
+                .map(r => r.outcome && typeof r.outcome === 'string' ? r.outcome.toLowerCase() : null)
+                .filter(o => o && Object.keys(allowedOutcomes).includes(o))
         );
-
         for (let outcome of uniqueOutcomes) {
-          await ZoteroIntegration.addTag(itemID, allowedOutcomes[outcome]);
+            await ZoteroIntegration.addTag(itemID, allowedOutcomes[outcome]);
         }
-      }
 
-      // Generate note content
-      const noteHTML = this.createReplicationNote(replications);
-
-      // Get parent item
-      const parentItem = await Zotero.Items.getAsync(itemID);
-
-      // Get child note IDs
-      const noteIDs = parentItem.getNotes();
-
-      let existingNote = null;
-      for (let noteID of noteIDs) {
-        const note = await Zotero.Items.getAsync(noteID);
-        const currentNoteHTML = note.getNote();
-        if (currentNoteHTML.startsWith('<h2>Replications Found</h2>')) {
-          existingNote = note;
-          break;
+        // Get child notes to find existing replication note
+        const noteIDs = item.getNotes();
+        let existingNote = null;
+        for (let noteID of noteIDs) {
+            const note = await Zotero.Items.getAsync(noteID);
+            const currentNoteHTML = note.getNote();
+            if (currentNoteHTML.startsWith('<h2>Replications Found</h2>')) {
+                existingNote = note;
+                break;
+            }
         }
-      }
 
-      if (existingNote) {
-        // Update existing note
-        existingNote.setNote(noteHTML);
-        await existingNote.saveTx();
-      } else {
-        // Create new note
-        await ZoteroIntegration.addNote(itemID, noteHTML);
-      }
+        if (existingNote) {
+            // Incremental update: Parse HTML and append new <li> if DOI not present
+            let currentHTML = existingNote.getNote();
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(currentHTML, 'text/html');
+            const ul = doc.querySelector('ul');
+            if (!ul) {
+                // Malformed note; overwrite as fallback
+                existingNote.setNote(this.createReplicationNote(uniqueReplications));
+                await existingNote.saveTx();
+                return;
+            }
+
+            // Extract existing DOIs from <li>s
+            const existingLis = Array.from(ul.querySelectorAll('li'));
+            const existingDOIs = new Set();
+            existingLis.forEach(liElem => {
+                const doiA = liElem.querySelector('a[href^="https://doi.org/"]');
+                if (doiA) {
+                    const doi = doiA.href.replace('https://doi.org/', '').trim();
+                    existingDOIs.add(doi);
+                }
+            });
+
+            // Append new <li>s if not duplicate
+            let added = false;
+            uniqueReplications.forEach(rep => {
+                const doi_r = (rep.doi_r || '').trim();
+                if (doi_r && !existingDOIs.has(doi_r)) {
+                    const newLiHTML = this._createReplicationLi(rep);
+                    ul.insertAdjacentHTML('beforeend', newLiHTML);  // Add to end of <ul>
+                    existingDOIs.add(doi_r);
+                    added = true;
+                }
+            });
+
+            if (added) {
+                const newHTML = doc.body.innerHTML;  // Serialize back (preserves user content after <ul>)
+                existingNote.setNote(newHTML);
+                await existingNote.saveTx();
+            }
+        } else {
+            // Create new note
+            const noteHTML = this.createReplicationNote(uniqueReplications);
+            await ZoteroIntegration.addNote(itemID, noteHTML);
+        }
+
+        // New: Automatically add replications to "Replication folder" collection
+        const libraryID = item.libraryID; // Use same library as original item (personal or group)
+        let collections = Zotero.Collections.getByLibrary(libraryID, true); // true for including subcollections, but we want top-level
+        let replicationCollection = collections.find(c => c.name === "Replication folder" && !c.hasParent());
+
+        if (!replicationCollection) {
+            replicationCollection = new Zotero.Collection();
+            replicationCollection.libraryID = libraryID;
+            replicationCollection.name = "Replication folder";
+            await replicationCollection.saveTx();
+            Zotero.debug(`Created new "Replication folder" collection in library ${libraryID}`);
+        }
+
+        for (let rep of uniqueReplications) {
+            const doi_r = (rep.doi_r || '').trim();
+            if (!doi_r || !doi_r.startsWith('10.')) {
+                Zotero.debug(`Skipping invalid or missing DOI for replication: ${doi_r}`);
+                continue; // Skip if no valid DOI
+            }
+
+            // Check for duplicate by DOI in the library
+            const search = new Zotero.Search();
+            search.libraryID = libraryID;
+            search.addCondition('DOI', 'is', doi_r);
+            const existingIDs = await search.search();
+            if (existingIDs.length > 0) {
+                Zotero.debug(`Skipping duplicate replication item with DOI: ${doi_r}`);
+                continue;
+            }
+
+            // Create new journal article item
+            const newItem = new Zotero.Item('journalArticle');
+            newItem.libraryID = libraryID;
+            newItem.setField('title', rep.title_r || 'Untitled Replication');
+            newItem.setField('publicationTitle', rep.journal_r || '');
+            newItem.setField('volume', rep.volume_r || '');
+            newItem.setField('issue', rep.issue_r || '');
+            newItem.setField('pages', rep.pages_r || '');
+            newItem.setField('date', rep.year_r ? rep.year_r.toString() : '');
+            newItem.setField('DOI', doi_r);
+
+            // Add authors
+            if (rep.author_r && Array.isArray(rep.author_r)) {
+                for (let author of rep.author_r) {
+                    newItem.addCreator({
+                        creatorType: 'author',
+                        firstName: author.given || '',
+                        lastName: author.family || ''
+                    });
+                }
+            }
+
+            // Save the new item
+            const newItemID = await newItem.saveTx();
+            Zotero.debug(`Added new replication item with ID ${newItemID} for DOI ${doi_r}`);
+
+            // Add to collection
+            replicationCollection.addItem(newItemID);
+            await replicationCollection.saveTx();
+        }
+
     } catch (error) {
-      throw new Error(`Failed to notify user for item ${itemID}: ${error.message}`);
+        throw new Error(`Failed to notify user for item ${itemID}: ${error.message}`);
     }
+  },
+
+  /**
+   * Parse authors from JSON string to APA format
+   * @param {Array} authors - Array of author objects
+   * @returns {string} - Formatted author string (e.g., "Hull, J. G., Slone, L. B., Meteyer, K. B., & Matthews, A. R.")
+   */
+  _parseAuthors(authors) {
+    if (!authors || !Array.isArray(authors) || authors.length === 0) return 'No authors available';
+    const authorStrings = authors.map(author => {
+      const initial = author.given ? author.given.split(' ').map(part => part[0] + '.').join(' ') : '';
+      return `${author.family}, ${initial}`;
+    });
+    return authorStrings.slice(0, -1).join(', ') + (authorStrings.length > 1 ? ' & ' : '') + authorStrings.slice(-1);
+  },
+
+  _createReplicationLi(rep) {
+    let li = '<li>';
+    li += '<i>This is an automatically generated note. Do not make changes!</i><br>';
+    li += `<strong>${this._escapeHtml(rep.title_r || 'No title available')}</strong><br>`;
+    li += `${this._parseAuthors(rep.author_r)} (${this._escapeHtml(rep.year_r || 'N/A')})<br>`;
+    li += `<em>${this._escapeHtml(rep.journal_r || 'No journal')}</em><br>`;
+    li += `DOI: <a href="https://doi.org/${this._escapeHtml(rep.doi_r || 'N/A')}">${this._escapeHtml(rep.doi_r || 'N/A')}</a><br>`;
+    if (rep.outcome) {
+        li += `Author Reported Outcome: <strong>${this._escapeHtml(rep.outcome)}</strong><br>`;
+    }
+    if (rep.doi_r && rep.doi_r.trim().toLowerCase() !== 'na' &&
+        rep.url_r && typeof rep.url_r === 'string' && rep.url_r.trim().toLowerCase() !== 'na' &&
+        rep.url_r.trim().startsWith('https')) {
+        li += `This study has a linked report: <a href="${this._escapeHtml(rep.url_r.trim())}" target="_blank">${this._escapeHtml(rep.url_r.trim())}</a><br>`;
+    }
+    li += '</li>';
+    return li;
   },
 
   /**
@@ -347,26 +561,8 @@ var ReplicationCheckerPlugin = {
     html += '<p>This study has been replicated:</p>';
     html += '<ul>';
     for (let rep of replications) {
-      html += '<li>';
-      html += '<i>This is an automatically generated note. Do not make changes!</i><br>';
-      html += `<strong>${this._escapeHtml(rep.title_r)}</strong><br>`;
-      html += `${this._escapeHtml(this._parseAuthors(rep.author_r))} (${this._escapeHtml(rep.year_r)})<br>`;
-      html += `<em>${this._escapeHtml(rep.journal_r)}</em><br>`;
-      html += `DOI: <a href="https://doi.org/${this._escapeHtml(rep.doi_r)}">${this._escapeHtml(rep.doi_r)}</a><br>`;
-
-      if (rep.outcome) {
-        html += `Author Reported Outcome: <strong>${this._escapeHtml(rep.outcome)}</strong><br>`;
-      }
-
-      // Conditional linking of report only if DOI is present and url_r is https link
-      if (rep.doi_r && rep.doi_r.trim().toLowerCase() !== 'na' &&
-        rep.url_r && typeof rep.url_r === 'string' && rep.url_r.trim().toLowerCase() !== 'na' &&
-        rep.url_r.trim().startsWith('https')) {
-        html += `This study has a linked report: <a href="${this._escapeHtml(rep.url_r.trim())}" target="_blank">${this._escapeHtml(rep.url_r.trim())}</a><br>`;
-      }
-      html += '</li>';
+        html += this._createReplicationLi(rep);
     }
-
     html += '</ul>';
     html += `
       <hr/>
@@ -376,21 +572,6 @@ var ReplicationCheckerPlugin = {
     `;
     html += '<p><small>Generated by Zotero Replication Checker using the FORRT Replication Database (FReD)</small></p>';
     return html;
-  },
-
-  /**
-   * Parse authors from JSON string
-   * @param {string} authorsJson
-   * @returns {string}
-   */
-  _parseAuthors(authorsJson) {
-    if (!authorsJson || authorsJson === 'null') return 'No authors available';
-    try {
-      const authors = JSON.parse(authorsJson);
-      return authors.map(a => `${a.family}, ${a.given}`).join('; ');
-    } catch (e) {
-      return authorsJson;
-    }
   },
 
   /**
@@ -412,12 +593,13 @@ var ReplicationCheckerPlugin = {
    * @param {number} doiCount
    * @param {number} totalItems
    * @param {boolean} isSelected
+   * @param {boolean} isCollection
    */
-  showResultsAlert(results, doiCount, totalItems, isSelected = false) {
+  showResultsAlert(results, doiCount, totalItems, isSelected = false, isCollection = false) {
     const win = Zotero.getMainWindow();
     if (!win) return;
 
-    let message = isSelected ? "Selected Items Scan Complete" : "Library Scan Complete";
+    let message = isCollection ? "Collection Scan Complete" : (isSelected ? "Selected Items Scan Complete" : "Library Scan Complete");
     message += `\nTotal items checked: ${totalItems}`;
     message += `\nItems with DOIs: ${doiCount}`;
     message += "\n\nReplication check results:";

--- a/addon/content/scripts/zotero-integration.js
+++ b/addon/content/scripts/zotero-integration.js
@@ -6,9 +6,10 @@
 var ZoteroIntegration = {
 
   async getAllDOIsFromLibrary() {
+    const libraryID = Zotero.getActiveZoteroPane().getSelectedLibraryID();
     const items = [];
-
     const search = new Zotero.Search();
+    search.libraryID = libraryID; 
     search.addCondition('itemType', 'isNot', 'attachment');
     search.addCondition('itemType', 'isNot', 'note');
     const itemIDs = await search.search();
@@ -16,12 +17,20 @@ var ZoteroIntegration = {
     Zotero.debug(`Found ${itemIDs.length} items in library`);
 
     for (let itemID of itemIDs) {
-      const item = await Zotero.Items.getAsync(itemID);
-      const doi = item.getField('DOI');
-
-      if (doi) {
-        items.push({ itemID, doi });
-      }
+        const item = await Zotero.Items.getAsync(itemID);
+        let doi = item.getField('DOI');
+        if (!doi) {
+            const extra = item.getField('extra');
+            if (extra) {
+                const doiMatch = extra.match(/doi\s*[:=]\s*([^\n]+)/i);
+                if (doiMatch) {
+                    doi = doiMatch[1].trim();
+                }
+            }
+        }
+        if (doi) {
+            items.push({ itemID, doi });
+        }
     }
 
     Zotero.debug(`Found ${items.length} items with DOIs`);
@@ -33,12 +42,70 @@ var ZoteroIntegration = {
     const selectedItems = Zotero.getActiveZoteroPane().getSelectedItems();
 
     for (let item of selectedItems) {
-      const doi = item.getField('DOI');
+      let doi = item.getField('DOI');
+      if (!doi) {
+          const extra = item.getField('extra');
+          if (extra) {
+              const doiMatch = extra.match(/doi\s*[:=]\s*([^\n]+)/i);
+              if (doiMatch) {
+                  doi = doiMatch[1].trim();
+              }
+          }
+      }
       if (doi) {
         items.push({ itemID: item.id, doi });
       }
     }
 
+    return items;
+  },
+
+  async getDOIsFromCollection(collectionID) {
+    const items = [];
+    const collection = Zotero.Collections.get(collectionID);
+    if (!collection) {
+      Zotero.debug(`Collection with ID ${collectionID} not found`);
+      return items;
+    }
+
+    const libraryID = collection.libraryID;
+    const processCollection = async (colID) => {
+      const col = Zotero.Collections.get(colID);
+      if (!col) return;
+
+      const search = new Zotero.Search();
+      search.libraryID = libraryID;
+      search.addCondition('collection', 'is', colID.toString());
+      search.addCondition('itemType', 'isNot', 'attachment');
+      search.addCondition('itemType', 'isNot', 'note');
+      const itemIDs = await search.search();
+
+      for (let itemID of itemIDs) {
+        const item = await Zotero.Items.getAsync(itemID);
+        let doi = item.getField('DOI');
+        if (!doi) {
+            const extra = item.getField('extra');
+            if (extra) {
+                const doiMatch = extra.match(/doi\s*[:=]\s*([^\n]+)/i);
+                if (doiMatch) {
+                    doi = doiMatch[1].trim();
+                }
+            }
+        }
+        if (doi) {
+          items.push({ itemID, doi });
+        }
+      }
+
+      // Recursively process subcollections
+      const subCollections = Zotero.Collections.getByParent(colID, true) || [];
+      for (let subCol of subCollections) {
+        await processCollection(subCol.id);
+      }
+    };
+
+    await processCollection(collectionID);
+    Zotero.debug(`Found ${items.length} items with DOIs in collection ${collectionID}`);
     return items;
   },
 
@@ -49,7 +116,9 @@ var ZoteroIntegration = {
   },
 
   async addNote(itemID, noteHTML) {
+    const parentItem = await Zotero.Items.getAsync(itemID);
     const note = new Zotero.Item('note');
+    note.libraryID = parentItem.libraryID;  
     note.parentID = itemID;
     note.setNote(noteHTML);
     await note.saveTx();


### PR DESCRIPTION
fix #3 
- Search for Replication Studies when a user add a new item
- If Replication Studies are found, it asks for confirmation to be added as a note.
- Also fix mozilla obsolete approach.