### PR TITLE
Improve plugin reliability and add configurable folder name

### DIFF
--- a/addon/content/preferences.xhtml
+++ b/addon/content/preferences.xhtml
@@ -17,6 +17,11 @@
     name="extensions.zotero.replication-checker.blacklist"
     type="string"
   />
+  <preference
+    id="pref-folderName"
+    name="extensions.zotero.replication-checker.folderName"
+    type="string"
+  />
 </preferences>
 
 <groupbox>
@@ -66,6 +71,25 @@
 
   <html:p id="pref-autocheck-note-label" style="margin-top: 15px; font-size: 0.85em; color: #999;">
     <html:strong id="pref-autocheck-note-strong">Note:</html:strong> Auto-check runs in the background when Zotero is open. You can still manually check using the Tools menu.
+  </html:p>
+</groupbox>
+
+<groupbox>
+  <label>
+    <html:h2 id="pref-folder-title-label">Replication Folder Name</html:h2>
+  </label>
+
+  <html:p id="pref-folder-description-label" style="margin: 0 0 12px 0; font-size: 0.9em; color: #666;">
+    Name of the Zotero collection where replication items are stored
+  </html:p>
+
+  <html:div style="display: flex; align-items: center; gap: 8px;">
+    <html:input id="pref-folder-name-input" type="text" preference="pref-folderName"
+      style="flex: 1; padding: 4px 8px; font-size: 0.9em;" placeholder="FLoRA Replications" />
+  </html:div>
+
+  <html:p id="pref-folder-hint-label" style="margin-top: 8px; font-size: 0.85em; color: #999;">
+    Changing this will create a new collection for future checks. Existing items will remain in the old collection.
   </html:p>
 </groupbox>
 
@@ -158,6 +182,11 @@ function localizePrefs() {
     noteEl.appendChild(strong);
     noteEl.appendChild(document.createTextNode(noteText.substring(noteText.indexOf(":") + 2)));
   }
+
+  // Folder name section
+  setText("pref-folder-title-label", "pref-folder-title");
+  setText("pref-folder-description-label", "pref-folder-description");
+  setText("pref-folder-hint-label", "pref-folder-hint");
 
   // Blacklist section
   setText("pref-blacklist-title-label", "pref-blacklist-title");

--- a/addon/locale/en-US/replication-checker.ftl
+++ b/addon/locale/en-US/replication-checker.ftl
@@ -67,7 +67,7 @@ replication-checker-readonly-dialog-title = Read-Only Library Detected
 replication-checker-readonly-dialog-message =
     This library is read-only. We found { $itemCount } item(s) with { $replicationCount } replication(s).
 
-    Would you like to copy the original articles and their replications to your Personal library's "Replication folder"?
+    Would you like to copy the original articles and their replications to your Personal library's replication folder?
 
 ## Results Messages
 replication-checker-results-title-library = Library Scan Complete

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -2,3 +2,4 @@
 pref("extensions.zotero.replication-checker.autoCheckFrequency", "monthly");
 pref("extensions.zotero.replication-checker.autoCheckNewItems", true);
 pref("extensions.zotero.replication-checker.blacklist", "");
+pref("extensions.zotero.replication-checker.folderName", "FLoRA Replications");

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "lint:fix": "prettier --write . && eslint . --fix",
     "release": "zotero-plugin release",
     "test": "zotero-plugin test",
-    "update-deps": "npm update --save"
+    "update-deps": "npm update --save",
+    "postinstall": "node scripts/patch-scaffold.mjs"
   },
   "dependencies": {
     "crypto-js": "^4.2.0",

--- a/scripts/patch-scaffold.mjs
+++ b/scripts/patch-scaffold.mjs
@@ -1,0 +1,30 @@
+/**
+ * Patch zotero-plugin-scaffold to replace '.grey' with '.gray' in style calls.
+ * Node.js 25+ removed 'grey' as a valid color name for styleText;
+ * 'gray' works in all versions.
+ */
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const dir = join(
+  "node_modules",
+  "zotero-plugin-scaffold",
+  "dist",
+  "shared",
+);
+
+try {
+  const files = await readdir(dir);
+  for (const file of files) {
+    if (!file.endsWith(".mjs")) continue;
+    const path = join(dir, file);
+    const content = await readFile(path, "utf8");
+    if (content.includes(".grey")) {
+      await writeFile(path, content.replaceAll(".grey", ".gray"));
+      console.log(`Patched ${path}: replaced .grey with .gray`);
+    }
+  }
+} catch (e) {
+  // Silently skip if scaffold is not installed yet (e.g., during initial npm install)
+  if (e.code !== "ENOENT") throw e;
+}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -744,19 +744,9 @@ export async function onShutdown() {
       Zotero.debug("[ReplicationChecker] Could not unregister preference observer: " + e);
     }
 
-    // Clear all plugin preferences on uninstall/disable
-    // This ensures fresh onboarding on reinstall
-    try {
-      Zotero.debug("[ReplicationChecker] Clearing plugin preferences");
-      Zotero.Prefs.clear("replication-checker.autoCheckFrequency");
-      Zotero.Prefs.clear("replication-checker.autoCheckNewItems");
-      Zotero.Prefs.clear("replication-checker.blacklist");
-      Zotero.Prefs.clear("replication-checker.onboardingVersion");
-      Zotero.Prefs.clear("replication-checker.firstRunDone");
-      Zotero.debug("[ReplicationChecker] Plugin preferences cleared");
-    } catch (e) {
-      Zotero.debug("[ReplicationChecker] Error clearing preferences: " + e);
-    }
+    // Note: We intentionally do NOT clear preferences on shutdown.
+    // Zotero calls onShutdown during auto-updates before reloading the new version,
+    // so clearing prefs here would reset user settings and re-trigger onboarding.
 
     // Cleanup global reference
     delete (Zotero as any).ReplicationChecker;

--- a/src/modules/batchMatcher.ts
+++ b/src/modules/batchMatcher.ts
@@ -19,14 +19,11 @@ export class BatchMatcher {
   private dataSource: ReplicationDataSource;
 
   /**
-   * Number of hash prefixes to send per API request
-   * Optimized for balance between payload size and number of requests:
-   * - 500 prefixes = ~2KB payload (well within limits)
-   * - Reduces API calls by 80% compared to batch size of 100
-   * - 1,000 items: 2 requests instead of 10 (60% faster)
-   * - 10,000 items: 20 requests instead of 97 (68% faster)
+   * Number of hash prefixes to send per API request.
+   * The FLoRA API processes at most 200 prefixes per request,
+   * silently ignoring any beyond that limit.
    */
-  private readonly BATCH_SIZE = 500;
+  private readonly BATCH_SIZE = 200;
 
   constructor(dataSource: ReplicationDataSource) {
     this.dataSource = dataSource;

--- a/src/modules/replicationChecker.ts
+++ b/src/modules/replicationChecker.ts
@@ -19,6 +19,20 @@ import { reproductionHandler } from "./reproductionHandler";
 
 const AUTO_CHECK_PREF = "replication-checker.autoCheckFrequency";
 const NEW_ITEM_PREF = "replication-checker.autoCheckNewItems";
+const FOLDER_NAME_PREF = "replication-checker.folderName";
+const DEFAULT_FOLDER_NAME = "FLoRA Replications";
+
+function getReplicationFolderName(): string {
+  try {
+    const prefValue = Zotero.Prefs.get(FOLDER_NAME_PREF);
+    if (typeof prefValue === "string" && prefValue.trim().length > 0) {
+      return prefValue.trim();
+    }
+  } catch (e) {
+    // Fall through to default
+  }
+  return DEFAULT_FOLDER_NAME;
+}
 
 type LocaleParams = Record<string, string | number>;
 const FEEDBACK_URL = "https://tinyurl.com/y5evebv9";
@@ -717,6 +731,11 @@ export class ReplicationCheckerPlugin {
 
       const collection = Zotero.getActiveZoteroPane().getSelectedCollection();
       if (!collection) {
+        // If a library is selected (not a collection), run the full library check
+        const selectedLibraryID = Zotero.getActiveZoteroPane().getSelectedLibraryID();
+        if (selectedLibraryID !== undefined) {
+          return this.checkEntireLibrary();
+        }
         this.showInfoAlert("replication-checker-alert-no-collection");
         return;
       }
@@ -1607,7 +1626,7 @@ export class ReplicationCheckerPlugin {
   }
 
   /**
-   * Add replications to the "Replication folder" collection
+   * Add replications to the replication folder collection
    */
   private async addReplicationsToFolder(itemID: number, replications: any[]): Promise<void> {
     try {
@@ -1654,17 +1673,18 @@ export class ReplicationCheckerPlugin {
       // Get or create replication collection
       const libraryID = item.libraryID;
       let collections = Zotero.Collections.getByLibrary(libraryID, true);
+      const folderName = getReplicationFolderName();
       let replicationCollection = collections.find(
-        (c: any) => c.name === "Replication folder" && !c.parentID
+        (c: any) => c.name === folderName && !c.parentID
       );
 
       if (!replicationCollection) {
         replicationCollection = new Zotero.Collection({
           libraryID: libraryID,
-          name: "Replication folder",
+          name: folderName,
         });
         await replicationCollection.saveTx();
-        Zotero.debug(`Created new "Replication folder" collection in library ${libraryID}`);
+        Zotero.debug(`Created new "${folderName}" collection in library ${libraryID}`);
       }
 
       // Process replications in transaction
@@ -1698,7 +1718,7 @@ export class ReplicationCheckerPlugin {
           }
 
           // If the replication item already exists in the library, don't create a duplicate.
-          // Instead, (a) make sure it's in the "Replication folder" collection and
+          // Instead, (a) make sure it's in the replication folder collection and
           // (b) link it as a related item to the original.
           if (existingIDs.length > 0) {
             Zotero.debug(
@@ -1713,11 +1733,11 @@ export class ReplicationCheckerPlugin {
               try {
                 await replicationCollection.addItem(existingID);
                 Zotero.debug(
-                  `Ensured existing replication item ${existingID} is in "Replication folder"`
+                  `Ensured existing replication item ${existingID} is in "${folderName}"`
                 );
               } catch (collectionError) {
                 Zotero.debug(
-                  `Failed to add existing replication item ${existingID} to "Replication folder": ${collectionError}`
+                  `Failed to add existing replication item ${existingID} to "${folderName}": ${collectionError}`
                 );
               }
 
@@ -1893,7 +1913,7 @@ export class ReplicationCheckerPlugin {
 
             // Add to collection
             await replicationCollection.addItem(newItemID);
-            Zotero.debug(`Added replication item ${newItemID} to "Replication folder"`);
+            Zotero.debug(`Added replication item ${newItemID} to "${folderName}"`);
           } catch (error) {
             Zotero.debug(`Error creating replication item for DOI ${doi_r}: ${error}`);
           }
@@ -2379,19 +2399,20 @@ export class ReplicationCheckerPlugin {
       const sourceLibrary = Zotero.Libraries.get(sourceLibraryID);
       const sourceLibraryName = sourceLibrary ? sourceLibrary.name : "Unknown Library";
 
-      // Get or create "Replication folder" in Personal library (for replications)
+      // Get or create replication folder in Personal library (for replications)
+      const folderName = getReplicationFolderName();
       let collections = Zotero.Collections.getByLibrary(personalLibraryID, true);
       let replicationCollection = collections.find(
-        (c: any) => c.name === "Replication folder" && !c.parentID
+        (c: any) => c.name === folderName && !c.parentID
       );
 
       if (!replicationCollection) {
         replicationCollection = new Zotero.Collection({
           libraryID: personalLibraryID,
-          name: "Replication folder",
+          name: folderName,
         });
         await replicationCollection.saveTx();
-        Zotero.debug(`[ReplicationChecker] Created "Replication folder" in Personal library`);
+        Zotero.debug(`[ReplicationChecker] Created "${folderName}" in Personal library`);
       }
 
       // Get or create collection for originals named "{LibraryName} [Read-Only]"
@@ -2462,7 +2483,7 @@ export class ReplicationCheckerPlugin {
             copiedOriginal.addTag(TAG_READONLY_ORIGIN);
             await copiedOriginal.save();
 
-            // Add original to the read-only library collection (not to Replication folder)
+            // Add original to the read-only library collection (not to replication folder)
             await originalsCollection.addItem(copiedOriginalID);
 
             // Deduplicate replications by DOI, URL, or title
@@ -2565,7 +2586,7 @@ export class ReplicationCheckerPlugin {
               await copiedOriginal.save();
               await replicationItem.save();
 
-              // Add to Replication folder
+              // Add to replication folder
               await replicationCollection.addItem(replicationItemID);
             }
 

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -59,7 +59,7 @@ export const strings = {
 
   // Read-Only Library Handling
   "replication-checker-readonly-dialog-title": "Read-Only Library Detected",
-  "replication-checker-readonly-dialog-message": "This library is read-only. We found { $itemCount } item(s) with { $replicationCount } replication(s).\n\nWould you like to copy the original articles and their replications to your Personal library's \"Replication folder\"?",
+  "replication-checker-readonly-dialog-message": "This library is read-only. We found { $itemCount } item(s) with { $replicationCount } replication(s).\n\nWould you like to copy the original articles and their replications to your Personal library's replication folder?",
 
   // Results Messages
   "replication-checker-results-title-library": "Library Scan Complete",
@@ -158,6 +158,9 @@ export const strings = {
   "pref-autocheck-new-items": "Automatically check newly added library items (recommended)",
   "pref-autocheck-new-items-hint": "Disable this option if you prefer to run all replication checks manually.",
   "pref-autocheck-note": "Auto-check runs in the background when Zotero is open. You can still manually check using the Tools menu.",
+  "pref-folder-title": "Replication Folder Name",
+  "pref-folder-description": "Name of the Zotero collection where replication items are stored",
+  "pref-folder-hint": "Changing this will create a new collection for future checks. Existing items will remain in the old collection.",
   "pref-blacklist-title": "Banned Replications",
   "pref-blacklist-description": "Manage replications you've banned from appearing in your library",
   "pref-blacklist-col-replication": "Replication Article",

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -10,6 +10,7 @@ declare namespace _ZoteroTypes {
       "autoCheckFrequency": string;
       "autoCheckNewItems": boolean;
       "blacklist": string;
+      "folderName": string;
     };
   }
 }


### PR DESCRIPTION
## Summary

- **Configurable replication folder name**: Added a new `folderName` preference (default: "FLoRA Replications") with a UI section in the preferences pane, replacing all hardcoded "Replication folder" references throughout the codebase
- **Fix batch size to match API limit**: Reduced `BATCH_SIZE` from 500 to 200 — the FLoRA API processes at most 200 prefixes per request, silently ignoring any beyond that limit
- **Stop clearing preferences on shutdown**: Removed pref-clearing from `onShutdown` because Zotero calls it during auto-updates before reloading the new version, which was resetting user settings and re-triggering onboarding
- **Fall back to full library check**: When a library (not a collection) is selected, the plugin now runs `checkEntireLibrary()` instead of showing a "no collection selected" error

Also adds a `postinstall` script to patch `zotero-plugin-scaffold` for Node.js 25+ compatibility (`.grey` → `.gray` style color name).

## Test plan

- [x] Install plugin and verify the new "Replication Folder Name" preference appears and persists
- [x] Change folder name and run a check — verify new collection is created with the custom name
- [x] Run a batch check with >200 items and verify all items are processed (batches of 200)
- [ ] Update the plugin and verify preferences are preserved across the update
- [x] Select a library (not a collection) and run a check — verify it scans the full library

🤖 Generated with [Claude Code](https://claude.com/claude-code)