### PR TITLE
Add European Portuguese (pt-PT) translation

### DIFF
--- a/addon/locale/pt-PT/replication-checker.ftl
+++ b/addon/locale/pt-PT/replication-checker.ftl
@@ -125,7 +125,7 @@ replication-checker-prompt-first-run =
     • Clique em "Cancel" para ignorar por agora - poderá sempre analisar mais tarde a partir do menu Ferramentas.
 
 ## Onboarding
-onboarding-welcome-title = Boas-vindas ao Replication Checker!
+onboarding-welcome-title = Boas-vindas ao Zotero Replication Checker!
 onboarding-welcome-content =
     Obrigado por instalar o Zotero Replication Checker!
 
@@ -166,7 +166,7 @@ onboarding-context-content =
     • Impede que replicações indesejadas voltem a ser adicionadas
 
     ⚙️ Preferências:
-    Editar → Configurações → Replication Checker
+    Editar → Configurações → Zotero Replication Checker
     • Frequência de verificação automática
     • Verificação automática de novos itens
 


### PR DESCRIPTION
This PR adds a European Portuguese (pt-PT) translation for the Zotero Replication Checker locale file.
Patrícia Arriaga translated the interface labels into pt-PT, while keeping the plugin name "Zotero Replication Checker" in English.
Please let me know if you would like any wording changes or terminology adjustments.