### PR TITLE
Fix snowball effect when checking for replications

### DIFF
--- a/src/modules/replicationChecker.ts
+++ b/src/modules/replicationChecker.ts
@@ -673,19 +673,6 @@ export class ReplicationCheckerPlugin {
         return;
       }
 
-      // First, check for items that are replications (have originals but no replications)
-      for (const result of results) {
-        if (result.replications.length === 0 && result.originals.length > 0) {
-          const matchingItems = selectedItems.filter(
-            (item) => this.matcher!.normalizeDoi(item.doi) === result.doi
-          );
-
-          for (const libraryItem of matchingItems) {
-            await this.showIsReplicationDialog(libraryItem.itemID, result);
-          }
-        }
-      }
-
       // Process results - group items by library and check permissions
       const itemsByLibrary = new Map<number, Map<number, any[]>>();
       const itemsWithReproductionsByLibrary = new Map<number, Map<number, RelatedStudy[]>>();
@@ -851,19 +838,6 @@ export class ReplicationCheckerPlugin {
         progressWin.startCloseTimer(4000);
         this.handleMatchError(error, "collection");
         return;
-      }
-
-      // First, check for items that are replications (have originals but no replications)
-      for (const result of results) {
-        if (result.replications.length === 0 && result.originals.length > 0) {
-          const matchingItems = selectedItems.filter(
-            (item) => this.matcher!.normalizeDoi(item.doi) === result.doi
-          );
-
-          for (const libraryItem of matchingItems) {
-            await this.showIsReplicationDialog(libraryItem.itemID, result);
-          }
-        }
       }
 
       // Process results - group items by library and check permissions


### PR DESCRIPTION
## Summary
- Remove automatic "add original articles?" prompts from `checkSelectedItems()` and `checkSelectedCollection()`
- This prevents a cascading loop where repeated runs keep finding originals → replications → originals, growing the library each time
- Users can still add originals explicitly via the right-click "Add Original" menu item
- The auto-check for newly added items retains the originals prompt as a discovery feature

## Test plan
- [ ] Select items and run "Check for Replications" — should only find replications, not prompt to add originals
- [ ] Check a collection — same behavior
- [ ] Add a replication study to library — auto-check should still offer to add its original
- [ ] Right-click "Add Original" on a replication study — should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)